### PR TITLE
Update peerDependency of rollup. Fixes #44

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "module-details-from-path": "^1.0.3"
   },
   "peerDependencies": {
-    "rollup": "^1.0.0"
+    "rollup": "^2.0.0"
   }
 }


### PR DESCRIPTION
You may want to update the devDependencies etc. as well before releasing a new version.